### PR TITLE
Add node scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^3.1.0",
     "gulp-uglify": "3.0.0"
+  },
+  "scripts": {
+    "dev": "gulp dev"
   }
 }


### PR DESCRIPTION
To run project type
`npm run dev` or
`yarn dev`

I deliberately use `dev` because the gulp config also use the word `dev`.

However I suggest using `start` if you guys want a shorter version since we can run
`npm start` instead of `npm run start` (it's essentially the same)
But for yarn guys it would be the same.