### PR TITLE
Fix amount show on modal to 2 digit

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
       qrcode.makeCode(generatePayload(ppID, amount));
       $("#pp-id-show").html(ppID);
       if (amount > 0.0) {
-        $("#amount-show").html(amount.toLocaleString() + " บาท");
+        $("#amount-show").html(Number(amount.toFixed(2)).toLocaleString() + " บาท");
       } else {
         $("#amount-show").html("");
       }


### PR DESCRIPTION
This pull request is

- Fix amount when show modal and Round amount

Ex.
```
input amount: 1234.211
showing amount: 1,234.21

input amount: 1234.217
showing amount: 1,234.22
```